### PR TITLE
fix typo: from 10 px to 10px

### DIFF
--- a/src/lib/DownloadDialog.svelte
+++ b/src/lib/DownloadDialog.svelte
@@ -62,7 +62,7 @@
         </div>
       </div>
       <div class="btn-grp">
-        <div>{width[0]} px X {height[0]}px</div>
+        <div>{width[0]}px X {height[0]}px</div>
         <button class="btn btn-download" on:click={() => downloadPng()}>
           <p>Download PNG</p>
           <img src={imgIcon} alt="icon for png" width="20px" />


### PR DESCRIPTION
In the download modal, the button says
`1024 px X 300px`:
![Screenshot 2022-01-10 at 4 25 25 PM](https://user-images.githubusercontent.com/67495678/148754622-5fca5153-5933-4b46-9074-a493bfd978ac.png)
I made it so that the extra space is removed:
`1024px X 300px`
 